### PR TITLE
added ion acceleration and a test for it, rearranged the way source t…

### DIFF
--- a/src/HallThruster.jl
+++ b/src/HallThruster.jl
@@ -17,6 +17,7 @@ include("ionization.jl")
 include("geometry.jl")
 include("boundaryconditions.jl")
 include("simulation.jl")
+include("sourceterms.jl")
 
 #dere
 # this change was made on main

--- a/src/ionization.jl
+++ b/src/ionization.jl
@@ -94,23 +94,3 @@ function load_ionization_reactions(species)
 
 	return reactions
 end
-
-function apply_reactions!(Q, U, reactions::Vector{HallThruster.IonizationReaction{HallThruster.LinearInterpolation{Float64, Float64}}}, 
-	species_range_dict, fluid, fluid_ranges, cell_volume, i::Int64)
-	ne = @views HallThruster.electron_density(U[:, i], fluid_ranges)/fluid.m
-    Te = 15.0 #in eV
-    dt = 1e-6
-	for r in reactions
-		reactant_index = species_range_dict[r.reactant][1]
-		product_index = species_range_dict[r.product][1]
-		n_reactant = U[reactant_index, i]/fluid.m
-		if n_reactant > 1
-			n_product = U[product_index, i]/fluid.m
-			k = r.rate_coeff
-			@views Q[reactant_index] -= ne * n_reactant * k(Te) * dt*fluid.m/cell_volume #can probably use periodic callback
-			println("$(Q[reactant_index])")
-			@views Q[product_index]  += ne * n_product  * k(Te) * dt*fluid.m/cell_volume #can probably use periodic callback
-			println("$(Q[product_index])")
-		end
-	end
-end

--- a/src/physicalconstants.jl
+++ b/src/physicalconstants.jl
@@ -1,6 +1,6 @@
 """
     e
-Electron mass (1.602176634e-19 kg)
+Electron charge (1.602176634e-19 Coulomb)
 """
 const e = 1.602176634e-19
 

--- a/src/sourceterms.jl
+++ b/src/sourceterms.jl
@@ -1,0 +1,32 @@
+function apply_reactions!(Q, U, params, i::Int64)
+    fluids, fluid_ranges = params.fluids, params.fluid_ranges
+	reactions, species_range_dict = params.reactions, params.species_range_dict
+    _, __, cell_volume = params.z_cell, params.z_edge, params.cell_volume
+
+    fluid = fluids[1].species.element
+	ne = @views HallThruster.electron_density(U[:, i], fluid_ranges)/fluid.m
+    Te = 15.0 #in eV
+    dt = 1e-6
+	for r in reactions
+		reactant_index = species_range_dict[r.reactant][1]
+		product_index = species_range_dict[r.product][1]
+		n_reactant = U[reactant_index, i]/fluid.m
+		if n_reactant > 1
+			n_product = U[product_index, i]/fluid.m
+			k = r.rate_coeff
+			@views Q[reactant_index] -= ne * n_reactant * k(Te) * dt*fluid.m/cell_volume #can probably use periodic callback
+			println("$(Q[reactant_index])")
+			@views Q[product_index]  += ne * n_product  * k(Te) * dt*fluid.m/cell_volume #can probably use periodic callback
+			println("$(Q[product_index])")
+		end
+	end
+end
+
+function apply_ion_acceleration!(Q, U, params, i)
+    fluids, fluid_ranges = params.fluids, params.fluid_ranges
+    for j in 1:length(fluids)
+        if fluids[j].species.Z > 0
+            @views Q[fluid_ranges[j][2]] = e/fluids[j].species.element.m*U[fluid_ranges[j][1], i]*params.E_d[i]*fluids[j].species.Z
+        end
+    end
+end

--- a/test/ovs_mms.jl
+++ b/test/ovs_mms.jl
@@ -14,8 +14,8 @@ end
 function perform_OVS(; MMS_CONSTS, fluxfn, reconstruct)
 
     #create a template definition of source! function somewhere
-    function source!(Q, U, reactions, species_range_dict, fluid_ranges, fluid, cell_volume, z, i)
-        mms!(Q, [z])
+    function source!(Q, U, params, i)
+        mms!(Q, [params.z_cell[i]])
     end
     
     function IC!(U, z, fluids, L)
@@ -26,7 +26,7 @@ function perform_OVS(; MMS_CONSTS, fluxfn, reconstruct)
         T1 = MMS_CONSTS.T_constant
         E = MMS_CONSTS.fluid.cv*T1 + 0.5*u1*u1
 
-        U .= [ρ1, ρ1, ρ1*u1] #[ρ1, ρ1*u1, ρ1*E]
+        U .= [ρ1, ρ1, ρ1*u1] #[ρ1, ρ1*u1, ρ1*E]f
         return U
     end
 

--- a/test/run.jl
+++ b/test/run.jl
@@ -1,20 +1,15 @@
-using Test, HallThruster
+using Test, HallThruster, Plots
 
 
-function source!(Q, U, reactions, species_range_dict, fluid_ranges, fluid, cell_volume, z, i)
-    HallThruster.apply_reactions!(Q, U, reactions, species_range_dict, fluid, fluid_ranges, cell_volume, i)
+function source!(Q, U, params, i)
+    #HallThruster.apply_reactions!(Q, U, params, i)
+    HallThruster.apply_ion_acceleration!(Q, U, params, i)
+    return Q
 end
 
-fluid = HallThruster.Xenon
-
 function IC!(U, z, fluids, L)
-    gas1 = fluids[1].species.element
-
     ρ1 = 1.0
     u1 = 300.0
-    T1 = 300.0
-    E = fluid.cv*T1 + 0.5*u1*u1
-
     U .= [ρ1, ρ1, ρ1*u1] #[ρ1, ρ1*u1, ρ1*E]
     return U
 end
@@ -22,25 +17,25 @@ end
 ρ1 = 1.0
 u1 = 300.0
 T1 = 300.0
-E = fluid.cv*T1 + 0.5*u1*u1
-ER = fluid.cv*(T1+100.0) + 0.5*(u1+0.0)*(u1+0.0)
 
 left_state = [ρ1, ρ1, ρ1*u1] # [ρ1, ρ1*u1, ρ1*E] 
 right_state = [ρ1, ρ1, ρ1*(u1+0.0)] # [ρ1, ρ1*(u1+0.0), ρ1*ER]
 BCs = (HallThruster.Dirichlet(left_state), HallThruster.Neumann())
 
-sim = HallThruster.MultiFluidSimulation(grid = HallThruster.generate_grid(HallThruster.SPT_100, 10), 
+sim = HallThruster.MultiFluidSimulation(grid = HallThruster.generate_grid(HallThruster.SPT_100, 100), 
 boundary_conditions = BCs,
-scheme = HallThruster.HyperbolicScheme(HallThruster.HLLE!, HallThruster.minmod, false),
+scheme = HallThruster.HyperbolicScheme(HallThruster.HLLE!, identity, false),
 initial_condition = IC!, 
 source_term! = source!, 
 fluids = [HallThruster.Fluid(HallThruster.Species(fluid, 0), HallThruster.ContinuityOnly(300.0, 300.0));
 HallThruster.Fluid(HallThruster.Species(fluid, 1), HallThruster.IsothermalEuler(300.0))],
 #[HallThruster.Fluid(HallThruster.Species(MMS_CONSTS.fluid, 0), HallThruster.EulerEquations())], 
-end_time = 2e-6, 
-saveat = [2e-6],
-timestepcontrol = (1e-6, false), #if adaptive true, given timestep ignored. Still sets initial timestep, therefore cannot be chosen arbitrarily large.
+end_time = 0.0002, 
+saveat = [0.0002],
+timestepcontrol = (1e-8, false), #if adaptive true, given timestep ignored. Still sets initial timestep, therefore cannot be chosen arbitrarily large.
 callback = nothing
 )
 
 sol = HallThruster.run_simulation(sim)
+
+#Plots.plot(sim.grid.cell_centers, sol.u[1][3, :])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -527,3 +527,9 @@ end
         println("Simulation with $(results[i].ncells) cells and dt $(results[i].timestep[1]) converged after $(round(results[i].solution.t[1]/results[i].timestep[1])) timesteps at time $(results[i].solution.t[1])")
     end
 end
+
+
+@testset "Test ion acceleration source term" begin
+    include("source.jl")
+    test_ion_accel_source(HallThruster.HLLE!, false, 0.0002, 1e-8)
+end

--- a/test/shock_tube_v2.jl
+++ b/test/shock_tube_v2.jl
@@ -26,7 +26,7 @@ function shock_tube(fluxfn, ncells, end_time)
         outer_radius = 0.05
     )
 
-    function source!(Q, U, reactions, species_range_dict, fluid_ranges, fluid, cell_volume, z, i)
+    function source!(Q, U, params, i)
        return Q
     end
         

--- a/test/source.jl
+++ b/test/source.jl
@@ -1,0 +1,46 @@
+function test_ion_accel_source(fluxfn, reconstruct, end_time, dt)
+
+    fluid = HallThruster.Xenon
+
+    function source!(Q, U, params, i)
+        #HallThruster.apply_reactions!(Q, U, params, i)
+        HallThruster.apply_ion_acceleration!(Q, U, params, i)
+        return Q
+    end
+    
+    function IC!(U, z, fluids, L)
+        ρ1 = 1.0
+        u1 = 300.0
+        U .= [ρ1, ρ1, ρ1*u1] #[ρ1, ρ1*u1, ρ1*E]
+        return U
+    end
+    
+    ρ1 = 1.0
+    u1 = 300.0
+    T1 = 300.0
+    
+    left_state = [ρ1, ρ1, ρ1*u1] # [ρ1, ρ1*u1, ρ1*E] 
+    right_state = [ρ1, ρ1, ρ1*(u1+0.0)] # [ρ1, ρ1*(u1+0.0), ρ1*ER]
+    BCs = (HallThruster.Dirichlet(left_state), HallThruster.Neumann())
+    
+    sim = HallThruster.MultiFluidSimulation(grid = HallThruster.generate_grid(HallThruster.SPT_100, 100), 
+    boundary_conditions = BCs,
+    scheme = HallThruster.HyperbolicScheme(fluxfn, HallThruster.minmod, reconstruct),
+    initial_condition = IC!, 
+    source_term! = source!, 
+    fluids = [HallThruster.Fluid(HallThruster.Species(fluid, 0), HallThruster.ContinuityOnly(300.0, 300.0));
+    HallThruster.Fluid(HallThruster.Species(fluid, 1), HallThruster.IsothermalEuler(300.0))],
+    #[HallThruster.Fluid(HallThruster.Species(MMS_CONSTS.fluid, 0), HallThruster.EulerEquations())], 
+    end_time = end_time, 
+    saveat = [end_time],
+    timestepcontrol = (dt, false), #if adaptive true, given timestep ignored. Still sets initial timestep, therefore cannot be chosen arbitrarily large.
+    callback = nothing
+    )
+    
+    sol = HallThruster.run_simulation(sim)
+
+    #check if ion exit velocity corresponds to energy conservation 
+    println("ion exit velocity: $(sol.u[1][3, end]./sol.u[1][2, end])")
+    @test sol.u[1][3, end]./sol.u[1][2, end]  ≈ sqrt(2*400*HallThruster.e/fluid.m) atol = 10000
+
+end


### PR DESCRIPTION
…erms are handled, look relatively neat now to me. The whole mms verification is huge, will clean up at some point. SSPRK schemes work with fixed timestep for everything we test for. created sourceterms.jl where I will put all the source term functions (except MMS) and a source.jl test file for testing the source term functions that can then be imported to runtests.jl. Need to check out ionization properly and come up with a test for it, then implement potential equation.